### PR TITLE
Expand unset environment variable to empty string

### DIFF
--- a/src/conf.erl
+++ b/src/conf.erl
@@ -217,7 +217,7 @@ expand_env(<<$$, _/binary>> = Env) ->
     expand_env(binary_to_list(Env));
 expand_env([$$|Env]) ->
     case os:getenv(Env) of
-        false -> [$$|Env];
+        false -> "";
         Value -> Value
     end;
 expand_env(Other) ->


### PR DESCRIPTION
Expand `$FOO_PREFIX/etc/foo.yml` to `/etc/foo.yml` if `$FOO_PREFIX` is unset.  I think that's the behavior admins would expect.  At least it's what I would expect :smile: