### PR TITLE
Make 'halt' behavior configurable

### DIFF
--- a/src/conf.erl
+++ b/src/conf.erl
@@ -208,12 +208,16 @@ get_env_file() ->
 
 -spec do_stop({error, term()}) -> {error, term()}.
 do_stop({error, Reason} = Err) ->
-    case application:get_env(conf, halt, false) of
-        true ->
+    case application:get_env(conf, on_fail, stop) of
+        stop ->
+            Err;
+        OnFail ->
             flush_logger(),
-            halt(format_error(Reason), [{flush, true}]);
-        _ ->
-            Err
+            Status = case OnFail of
+                         crash -> format_error(Reason);
+                         _Halt -> 1
+                     end,
+            halt(Status, [{flush, true}])
     end.
 
 -spec flush_logger() -> ok.

--- a/src/conf.erl
+++ b/src/conf.erl
@@ -217,7 +217,7 @@ do_stop({error, Reason} = Err) ->
                          crash -> format_error(Reason);
                          _Halt -> 1
                      end,
-            halt(Status, [{flush, true}])
+            halt(Status)
     end.
 
 -spec flush_logger() -> ok.


### PR DESCRIPTION
I don't really want the VM to generate crash dumps on configuration errors.  Therefore, replace the boolean `halt` setting with `on_fail`, which can be set to `stop` (to stop the `conf` application), `halt` (to halt the VM), or `crash` (to halt the VM and generate a crash dump).

I also removed the `{flush, true}` option from the `halt()` call.  According to [the docs][1], it's the default if `halt(Status)` is called with an integer `Status`, and it's ignored with a non-integer `Status`:

> For integer `Status`, the Erlang runtime system closes all ports and allows async threads to finish their operations before exiting. To exit without such flushing, use `Option` as `{flush, false}`.
>
> For statuses `string()` and `abort`, option flush is ignored and flushing is not done.

... which is another reason I don't want `halt()` to crash.

[1]: http://erlang.org/doc/man/erlang.html#halt-2