### PR TITLE
Expand path for configuration load error message

### DIFF
--- a/src/conf.erl
+++ b/src/conf.erl
@@ -113,7 +113,7 @@ start(_StartType, _StartArgs) ->
                 {error, Reason} = Err ->
                     logger:critical(
                       "Failed to load configuration from ~ts: ~ts",
-                      [Path, format_error(Reason)]),
+                      [conf_file:format_ref(Path), format_error(Reason)]),
                     do_stop(Err)
             end;
         {error, {undefined_env, _}} ->

--- a/src/conf_file.erl
+++ b/src/conf_file.erl
@@ -77,8 +77,13 @@ format_error({http, Reason}) ->
 -spec format_ref(ref()) -> binary().
 format_ref(#{} = URI) ->
     uri_string:normalize(URI);
-format_ref(Path) ->
-    Path.
+format_ref(Path0) ->
+    case expand_path(Path0) of
+        {ok, Path} ->
+            Path;
+        {error, _Reason} ->
+            Path0
+    end.
 
 %%%===================================================================
 %%% Internal functions


### PR DESCRIPTION
If loading the configuration fails, expand any OS environment variables specified within the configuration file path before generating the error message.

Closes #7.